### PR TITLE
RotationVector.parametersToInverseSMatrix()

### DIFF
--- a/sm_kinematics/include/sm/kinematics/RotationVector.hpp
+++ b/sm_kinematics/include/sm/kinematics/RotationVector.hpp
@@ -13,7 +13,9 @@ namespace sm { namespace kinematics {
       virtual Eigen::Vector3d rotationMatrixToParameters(const Eigen::Matrix3d & rotationMatrix) const;
       virtual Eigen::Matrix3d parametersToSMatrix(const Eigen::Vector3d & parameters) const;
       virtual Eigen::Vector3d angularVelocityAndJacobian(const Eigen::Vector3d & p, const Eigen::Vector3d & pdot, Eigen::Matrix<double,3,6> * Jacobian) const;    
-    };
+      // Fabio:
+	  Eigen::Matrix3d parametersToInverseSMatrix(const Eigen::Vector3d & parameters) const;
+	};
 
   }} // sm::kinematics
 

--- a/sm_kinematics/src/RotationVector.cpp
+++ b/sm_kinematics/src/RotationVector.cpp
@@ -180,5 +180,22 @@ namespace sm { namespace kinematics {
     }
 
 
+    Eigen::Matrix3d RotationVector::parametersToInverseSMatrix(const Eigen::Vector3d & parameters) const
+    {
+      double phi = std::sqrt(parameters.transpose()*parameters);
+      Eigen::Matrix3d invS;
+      if(phi == 0)
+      {
+        invS = Eigen::Matrix3d::Identity();
+      }
+      else
+      {
+        double cot = - std::sin(phi)/(std::cos(phi)-1);
+        double a1 = 1/(phi*phi) * (1- 0.5*phi*cot);
+        invS = Eigen::Matrix3d::Identity() + 0.5*crossMx(parameters) + a1*crossMx(parameters)*crossMx(parameters);
+      }
+      return invS;
+    }
+
 
   }} // sm::kinematics


### PR DESCRIPTION
adds RotationVector.parametersToInverseSMatrix() based on the screenshots you sent me a few weeks ago. the other functions of RotationVector are not changed (I don't know why the diff says otherwise).
