### PR TITLE
Better rounding error workaround

### DIFF
--- a/sm_kinematics/src/rotations.cpp
+++ b/sm_kinematics/src/rotations.cpp
@@ -131,13 +131,13 @@ namespace sm { namespace kinematics {
   }
 	
   Eigen::Vector3d R2AxisAngle(Eigen::Matrix3d const & C){
-
-    // Sometimes, because of roundoff error, the value of tr ends up outside
-    // the valid range of arccos. Truncate to the valid range.
-    double tr = std::max(-1.0, std::min( (C(0,0) + C(1,1) + C(2,2) - 1.0) * 0.5, 1.0));
-    double a = acos( tr ) ;
-
+    double a = acos( (C(0,0) + C(1,1) + C(2,2) - double(1)) * double(0.5));
     Eigen::Vector3d axis;
+
+    if (boost::math::isnan(a)) {
+      std::cout << "[WARNING]: Improper rotation matrix: trace(C) > 3." << std::endl;
+      return Eigen::Vector3d::Zero();
+    }
 
     if(fabs(a) < 1e-10) {
       return Eigen::Vector3d::Zero();


### PR DESCRIPTION
Some time ago I replaced my rounding error workaround in R2AxisAngle() with a more correct one you used somewhere else in Schweizer-Messer (I don't remember where exactly)
