### PR TITLE
added boost array header include to fix compilation error

### DIFF
--- a/sm_eigen/include/sm/eigen/serialization.hpp
+++ b/sm_eigen/include/sm/eigen/serialization.hpp
@@ -16,6 +16,7 @@
 #include <sm/assert_macros.hpp>
 #include <boost/serialization/split_free.hpp>
 #include <boost/serialization/nvp.hpp>
+#include <boost/serialization/array.hpp>
 
 namespace sm { namespace eigen {
     // An exception for errors during serialization/deserialization


### PR DESCRIPTION
added boost array header include to fix compilation error on ros groovy/ubuntu 12.10-64/gcc4.7.

Error:

Building CXX object CMakeFiles/sm_pose_graph.dir/src/PoseGraph.cpp.o
/home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp: In member function ‘bool sm::pose_graph::PoseGraph::edgeExists(sm::pose_graph::VertexId, sm::pose_graph::VertexId) const’:
/home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:356:18: warning: variable ‘invert’ set but not used [-Wunused-but-set-variable]
In file included from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/PoseGraph.hpp:46:0,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:43:
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp: In instantiation of ‘void boost::serialization::save(Archive&, const Eigen::Matrix<Scalar, A, B, C, D, E>&, unsigned int) [with Archive = boost::archive::binary_oarchive; Scalar = double; int A = 6; int B = 6; int C = 0; int D = 6; int E = 6]’:
/usr/include/boost/serialization/split_free.hpp:45:9:   required from ‘static void boost::serialization::free_saver<Archive, T>::invoke(Archive&, const T&, unsigned int) [with Archive = boost::archive::binary_oarchive; T = Eigen::Matrix<double, 6, 6>]’
/usr/include/boost/serialization/split_free.hpp:74:5:   required from ‘void boost::serialization::split_free(Archive&, T&, unsigned int) [with Archive = boost::archive::binary_oarchive; T = Eigen::Matrix<double, 6, 6>]’
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp:193:7:   required from ‘void boost::serialization::serialize(Archive&, Eigen::Matrix<Scalar, A, B, C, D, E>&, unsigned int) [with Archive = boost::archive::binary_oarchive; Scalar = double; int A = 6; int B = 6; int C = 0; int D = 6; int E = 6]’
/usr/include/boost/serialization/serialization.hpp:128:9:   required from ‘void boost::serialization::serialize_adl(Archive&, T&, unsigned int) [with Archive = boost::archive::binary_oarchive; T = Eigen::Matrix<double, 6, 6>]’
/usr/include/boost/archive/detail/oserializer.hpp:148:5:   required from ‘void boost::archive::detail::oserializer<Archive, T>::save_object_data(boost::archive::detail::basic_oarchive&, const void_) const [with Archive = boost::archive::binary_oarchive; T = Eigen::Matrix<double, 6, 6>]’
/usr/include/boost/archive/detail/oserializer.hpp:101:1:   [ skipping 189 instantiation contexts ]
/usr/include/boost/archive/detail/oserializer.hpp:525:5:   required from ‘void boost::archive::save(Archive&, T&) [with Archive = boost::archive::binary_oarchive; T = const sm::pose_graph::PoseGraph]’
/usr/include/boost/archive/detail/common_oarchive.hpp:69:9:   required from ‘void boost::archive::detail::common_oarchive<Archive>::save_override(T&, int) [with T = const sm::pose_graph::PoseGraph; Archive = boost::archive::binary_oarchive]’
/usr/include/boost/archive/basic_binary_oarchive.hpp:75:7:   required from ‘void boost::archive::basic_binary_oarchive<Archive>::save_override(const T&, int) [with T = sm::pose_graph::PoseGraph; Archive = boost::archive::binary_oarchive]’
/usr/include/boost/archive/binary_oarchive_impl.hpp:51:9:   required from ‘void boost::archive::binary_oarchive_impl<Archive, Elem, Tr>::save_override(T&, int) [with T = const sm::pose_graph::PoseGraph; Archive = boost::archive::binary_oarchive; Elem = char; Tr = std::char_traits<char>]’
/usr/include/boost/archive/detail/interface_oarchive.hpp:63:9:   required from ‘Archive& boost::archive::detail::interface_oarchive<Archive>::operator<<(T&) [with T = const sm::pose_graph::PoseGraph; Archive = boost::archive::binary_oarchive]’
/home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:295:20:   required from here
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp:54:11: error: ‘make_array’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
In file included from /usr/include/boost/archive/detail/oserializer.hpp:58:0,
                 from /usr/include/boost/archive/detail/interface_oarchive.hpp:23,
                 from /usr/include/boost/archive/detail/common_oarchive.hpp:22,
                 from /usr/include/boost/archive/basic_text_oarchive.hpp:32,
                 from /usr/include/boost/archive/text_oarchive.hpp:31,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_boost/include/sm/boost/serialization.hpp:5,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/Vertex.hpp:6,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/Edge.hpp:5,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/PoseGraph.hpp:48,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:43:
/usr/include/boost/serialization/array.hpp:127:12: note: ‘template<class T> const boost::serialization::array<T> boost::serialization::make_array(T_, std::size_t)’ declared here, later in the translation unit
In file included from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/PoseGraph.hpp:46:0,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:43:
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp: In instantiation of ‘void boost::serialization::load(Archive&, Eigen::Matrix<Scalar, A, B, C, D, E>&, unsigned int) [with Archive = boost::archive::binary_iarchive; Scalar = double; int A = 6; int B = 6; int C = 0; int D = 6; int E = 6]’:
/usr/include/boost/serialization/split_free.hpp:58:9:   required from ‘static void boost::serialization::free_loader<Archive, T>::invoke(Archive&, T&, unsigned int) [with Archive = boost::archive::binary_iarchive; T = Eigen::Matrix<double, 6, 6>]’
/usr/include/boost/serialization/split_free.hpp:74:5:   required from ‘void boost::serialization::split_free(Archive&, T&, unsigned int) [with Archive = boost::archive::binary_iarchive; T = Eigen::Matrix<double, 6, 6>]’
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp:193:7:   required from ‘void boost::serialization::serialize(Archive&, Eigen::Matrix<Scalar, A, B, C, D, E>&, unsigned int) [with Archive = boost::archive::binary_iarchive; Scalar = double; int A = 6; int B = 6; int C = 0; int D = 6; int E = 6]’
/usr/include/boost/serialization/serialization.hpp:128:9:   required from ‘void boost::serialization::serialize_adl(Archive&, T&, unsigned int) [with Archive = boost::archive::binary_iarchive; T = Eigen::Matrix<double, 6, 6>]’
/usr/include/boost/archive/detail/iserializer.hpp:188:5:   required from ‘void boost::archive::detail::iserializer<Archive, T>::load_object_data(boost::archive::detail::basic_iarchive&, void_, unsigned int) const [with Archive = boost::archive::binary_iarchive; T = Eigen::Matrix<double, 6, 6>]’
/usr/include/boost/archive/detail/iserializer.hpp:120:1:   [ skipping 189 instantiation contexts ]
/usr/include/boost/archive/detail/iserializer.hpp:592:5:   required from ‘void boost::archive::load(Archive&, T&) [with Archive = boost::archive::binary_iarchive; T = sm::pose_graph::PoseGraph]’
/usr/include/boost/archive/detail/common_iarchive.hpp:66:9:   required from ‘void boost::archive::detail::common_iarchive<Archive>::load_override(T&, int) [with T = sm::pose_graph::PoseGraph; Archive = boost::archive::binary_iarchive]’
/usr/include/boost/archive/basic_binary_iarchive.hpp:70:7:   required from ‘void boost::archive::basic_binary_iarchive<Archive>::load_override(T&, int) [with T = sm::pose_graph::PoseGraph; Archive = boost::archive::binary_iarchive]’
/usr/include/boost/archive/binary_iarchive_impl.hpp:50:9:   required from ‘void boost::archive::binary_iarchive_impl<Archive, Elem, Tr>::load_override(T&, int) [with T = sm::pose_graph::PoseGraph; Archive = boost::archive::binary_iarchive; Elem = char; Tr = std::char_traits<char>]’
/usr/include/boost/archive/detail/interface_iarchive.hpp:60:9:   required from ‘Archive& boost::archive::detail::interface_iarchive<Archive>::operator>>(T&) [with T = sm::pose_graph::PoseGraph; Archive = boost::archive::binary_iarchive]’
/home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:305:20:   required from here
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp:85:4: error: ‘make_array’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
In file included from /usr/include/boost/archive/detail/oserializer.hpp:58:0,
                 from /usr/include/boost/archive/detail/interface_oarchive.hpp:23,
                 from /usr/include/boost/archive/detail/common_oarchive.hpp:22,
                 from /usr/include/boost/archive/basic_text_oarchive.hpp:32,
                 from /usr/include/boost/archive/text_oarchive.hpp:31,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_boost/include/sm/boost/serialization.hpp:5,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/Vertex.hpp:6,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/Edge.hpp:5,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/PoseGraph.hpp:48,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:43:
/usr/include/boost/serialization/array.hpp:127:12: note: ‘template<class T> const boost::serialization::array<T> boost::serialization::make_array(T_, std::size_t)’ declared here, later in the translation unit
In file included from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/PoseGraph.hpp:46:0,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:43:
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp: In instantiation of ‘void boost::serialization::load(Archive&, Eigen::Matrix<Scalar, A, B, C, D, E>&, unsigned int) [with Archive = boost::archive::binary_iarchive; Scalar = double; int A = 4; int B = 1; int C = 0; int D = 4; int E = 1]’:
/usr/include/boost/serialization/split_free.hpp:58:9:   required from ‘static void boost::serialization::free_loader<Archive, T>::invoke(Archive&, T&, unsigned int) [with Archive = boost::archive::binary_iarchive; T = Eigen::Matrix<double, 4, 1>]’
/usr/include/boost/serialization/split_free.hpp:74:5:   required from ‘void boost::serialization::split_free(Archive&, T&, unsigned int) [with Archive = boost::archive::binary_iarchive; T = Eigen::Matrix<double, 4, 1>]’
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp:193:7:   required from ‘void boost::serialization::serialize(Archive&, Eigen::Matrix<Scalar, A, B, C, D, E>&, unsigned int) [with Archive = boost::archive::binary_iarchive; Scalar = double; int A = 4; int B = 1; int C = 0; int D = 4; int E = 1]’
/usr/include/boost/serialization/serialization.hpp:128:9:   required from ‘void boost::serialization::serialize_adl(Archive&, T&, unsigned int) [with Archive = boost::archive::binary_iarchive; T = Eigen::Matrix<double, 4, 1>]’
/usr/include/boost/archive/detail/iserializer.hpp:188:5:   required from ‘void boost::archive::detail::iserializer<Archive, T>::load_object_data(boost::archive::detail::basic_iarchive&, void_, unsigned int) const [with Archive = boost::archive::binary_iarchive; T = Eigen::Matrix<double, 4, 1>]’
/usr/include/boost/archive/detail/iserializer.hpp:120:1:   [ skipping 221 instantiation contexts ]
/usr/include/boost/archive/detail/iserializer.hpp:592:5:   required from ‘void boost::archive::load(Archive&, T&) [with Archive = boost::archive::binary_iarchive; T = sm::pose_graph::PoseGraph]’
/usr/include/boost/archive/detail/common_iarchive.hpp:66:9:   required from ‘void boost::archive::detail::common_iarchive<Archive>::load_override(T&, int) [with T = sm::pose_graph::PoseGraph; Archive = boost::archive::binary_iarchive]’
/usr/include/boost/archive/basic_binary_iarchive.hpp:70:7:   required from ‘void boost::archive::basic_binary_iarchive<Archive>::load_override(T&, int) [with T = sm::pose_graph::PoseGraph; Archive = boost::archive::binary_iarchive]’
/usr/include/boost/archive/binary_iarchive_impl.hpp:50:9:   required from ‘void boost::archive::binary_iarchive_impl<Archive, Elem, Tr>::load_override(T&, int) [with T = sm::pose_graph::PoseGraph; Archive = boost::archive::binary_iarchive; Elem = char; Tr = std::char_traits<char>]’
/usr/include/boost/archive/detail/interface_iarchive.hpp:60:9:   required from ‘Archive& boost::archive::detail::interface_iarchive<Archive>::operator>>(T&) [with T = sm::pose_graph::PoseGraph; Archive = boost::archive::binary_iarchive]’
/home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:305:20:   required from here
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp:85:4: error: ‘make_array’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
In file included from /usr/include/boost/archive/detail/oserializer.hpp:58:0,
                 from /usr/include/boost/archive/detail/interface_oarchive.hpp:23,
                 from /usr/include/boost/archive/detail/common_oarchive.hpp:22,
                 from /usr/include/boost/archive/basic_text_oarchive.hpp:32,
                 from /usr/include/boost/archive/text_oarchive.hpp:31,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_boost/include/sm/boost/serialization.hpp:5,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/Vertex.hpp:6,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/Edge.hpp:5,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/PoseGraph.hpp:48,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:43:
/usr/include/boost/serialization/array.hpp:127:12: note: ‘template<class T> const boost::serialization::array<T> boost::serialization::make_array(T_, std::size_t)’ declared here, later in the translation unit
In file included from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/PoseGraph.hpp:46:0,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:43:
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp: In instantiation of ‘void boost::serialization::load(Archive&, Eigen::Matrix<Scalar, A, B, C, D, E>&, unsigned int) [with Archive = boost::archive::binary_iarchive; Scalar = double; int A = 3; int B = 1; int C = 0; int D = 3; int E = 1]’:
/usr/include/boost/serialization/split_free.hpp:58:9:   required from ‘static void boost::serialization::free_loader<Archive, T>::invoke(Archive&, T&, unsigned int) [with Archive = boost::archive::binary_iarchive; T = Eigen::Matrix<double, 3, 1>]’
/usr/include/boost/serialization/split_free.hpp:74:5:   required from ‘void boost::serialization::split_free(Archive&, T&, unsigned int) [with Archive = boost::archive::binary_iarchive; T = Eigen::Matrix<double, 3, 1>]’
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp:193:7:   required from ‘void boost::serialization::serialize(Archive&, Eigen::Matrix<Scalar, A, B, C, D, E>&, unsigned int) [with Archive = boost::archive::binary_iarchive; Scalar = double; int A = 3; int B = 1; int C = 0; int D = 3; int E = 1]’
/usr/include/boost/serialization/serialization.hpp:128:9:   required from ‘void boost::serialization::serialize_adl(Archive&, T&, unsigned int) [with Archive = boost::archive::binary_iarchive; T = Eigen::Matrix<double, 3, 1>]’
/usr/include/boost/archive/detail/iserializer.hpp:188:5:   required from ‘void boost::archive::detail::iserializer<Archive, T>::load_object_data(boost::archive::detail::basic_iarchive&, void_, unsigned int) const [with Archive = boost::archive::binary_iarchive; T = Eigen::Matrix<double, 3, 1>]’
/usr/include/boost/archive/detail/iserializer.hpp:120:1:   [ skipping 221 instantiation contexts ]
/usr/include/boost/archive/detail/iserializer.hpp:592:5:   required from ‘void boost::archive::load(Archive&, T&) [with Archive = boost::archive::binary_iarchive; T = sm::pose_graph::PoseGraph]’
/usr/include/boost/archive/detail/common_iarchive.hpp:66:9:   required from ‘void boost::archive::detail::common_iarchive<Archive>::load_override(T&, int) [with T = sm::pose_graph::PoseGraph; Archive = boost::archive::binary_iarchive]’
/usr/include/boost/archive/basic_binary_iarchive.hpp:70:7:   required from ‘void boost::archive::basic_binary_iarchive<Archive>::load_override(T&, int) [with T = sm::pose_graph::PoseGraph; Archive = boost::archive::binary_iarchive]’
/usr/include/boost/archive/binary_iarchive_impl.hpp:50:9:   required from ‘void boost::archive::binary_iarchive_impl<Archive, Elem, Tr>::load_override(T&, int) [with T = sm::pose_graph::PoseGraph; Archive = boost::archive::binary_iarchive; Elem = char; Tr = std::char_traits<char>]’
/usr/include/boost/archive/detail/interface_iarchive.hpp:60:9:   required from ‘Archive& boost::archive::detail::interface_iarchive<Archive>::operator>>(T&) [with T = sm::pose_graph::PoseGraph; Archive = boost::archive::binary_iarchive]’
/home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:305:20:   required from here
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp:85:4: error: ‘make_array’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
In file included from /usr/include/boost/archive/detail/oserializer.hpp:58:0,
                 from /usr/include/boost/archive/detail/interface_oarchive.hpp:23,
                 from /usr/include/boost/archive/detail/common_oarchive.hpp:22,
                 from /usr/include/boost/archive/basic_text_oarchive.hpp:32,
                 from /usr/include/boost/archive/text_oarchive.hpp:31,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_boost/include/sm/boost/serialization.hpp:5,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/Vertex.hpp:6,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/Edge.hpp:5,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/PoseGraph.hpp:48,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:43:
/usr/include/boost/serialization/array.hpp:127:12: note: ‘template<class T> const boost::serialization::array<T> boost::serialization::make_array(T_, std::size_t)’ declared here, later in the translation unit
In file included from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/PoseGraph.hpp:46:0,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:43:
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp: In instantiation of ‘void boost::serialization::save(Archive&, const Eigen::Matrix<Scalar, A, B, C, D, E>&, unsigned int) [with Archive = boost::archive::binary_oarchive; Scalar = double; int A = 4; int B = 1; int C = 0; int D = 4; int E = 1]’:
/usr/include/boost/serialization/split_free.hpp:45:9:   required from ‘static void boost::serialization::free_saver<Archive, T>::invoke(Archive&, const T&, unsigned int) [with Archive = boost::archive::binary_oarchive; T = Eigen::Matrix<double, 4, 1>]’
/usr/include/boost/serialization/split_free.hpp:74:5:   required from ‘void boost::serialization::split_free(Archive&, T&, unsigned int) [with Archive = boost::archive::binary_oarchive; T = Eigen::Matrix<double, 4, 1>]’
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp:193:7:   required from ‘void boost::serialization::serialize(Archive&, Eigen::Matrix<Scalar, A, B, C, D, E>&, unsigned int) [with Archive = boost::archive::binary_oarchive; Scalar = double; int A = 4; int B = 1; int C = 0; int D = 4; int E = 1]’
/usr/include/boost/serialization/serialization.hpp:128:9:   required from ‘void boost::serialization::serialize_adl(Archive&, T&, unsigned int) [with Archive = boost::archive::binary_oarchive; T = Eigen::Matrix<double, 4, 1>]’
/usr/include/boost/archive/detail/oserializer.hpp:148:5:   required from ‘void boost::archive::detail::oserializer<Archive, T>::save_object_data(boost::archive::detail::basic_oarchive&, const void_) const [with Archive = boost::archive::binary_oarchive; T = Eigen::Matrix<double, 4, 1>]’
/usr/include/boost/archive/detail/oserializer.hpp:101:1:   [ skipping 222 instantiation contexts ]
/usr/include/boost/archive/detail/oserializer.hpp:525:5:   required from ‘void boost::archive::save(Archive&, T&) [with Archive = boost::archive::binary_oarchive; T = const sm::pose_graph::PoseGraph]’
/usr/include/boost/archive/detail/common_oarchive.hpp:69:9:   required from ‘void boost::archive::detail::common_oarchive<Archive>::save_override(T&, int) [with T = const sm::pose_graph::PoseGraph; Archive = boost::archive::binary_oarchive]’
/usr/include/boost/archive/basic_binary_oarchive.hpp:75:7:   required from ‘void boost::archive::basic_binary_oarchive<Archive>::save_override(const T&, int) [with T = sm::pose_graph::PoseGraph; Archive = boost::archive::binary_oarchive]’
/usr/include/boost/archive/binary_oarchive_impl.hpp:51:9:   required from ‘void boost::archive::binary_oarchive_impl<Archive, Elem, Tr>::save_override(T&, int) [with T = const sm::pose_graph::PoseGraph; Archive = boost::archive::binary_oarchive; Elem = char; Tr = std::char_traits<char>]’
/usr/include/boost/archive/detail/interface_oarchive.hpp:63:9:   required from ‘Archive& boost::archive::detail::interface_oarchive<Archive>::operator<<(T&) [with T = const sm::pose_graph::PoseGraph; Archive = boost::archive::binary_oarchive]’
/home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:295:20:   required from here
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp:54:11: error: ‘make_array’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
In file included from /usr/include/boost/archive/detail/oserializer.hpp:58:0,
                 from /usr/include/boost/archive/detail/interface_oarchive.hpp:23,
                 from /usr/include/boost/archive/detail/common_oarchive.hpp:22,
                 from /usr/include/boost/archive/basic_text_oarchive.hpp:32,
                 from /usr/include/boost/archive/text_oarchive.hpp:31,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_boost/include/sm/boost/serialization.hpp:5,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/Vertex.hpp:6,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/Edge.hpp:5,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/PoseGraph.hpp:48,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:43:
/usr/include/boost/serialization/array.hpp:127:12: note: ‘template<class T> const boost::serialization::array<T> boost::serialization::make_array(T_, std::size_t)’ declared here, later in the translation unit
In file included from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/PoseGraph.hpp:46:0,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:43:
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp: In instantiation of ‘void boost::serialization::save(Archive&, const Eigen::Matrix<Scalar, A, B, C, D, E>&, unsigned int) [with Archive = boost::archive::binary_oarchive; Scalar = double; int A = 3; int B = 1; int C = 0; int D = 3; int E = 1]’:
/usr/include/boost/serialization/split_free.hpp:45:9:   required from ‘static void boost::serialization::free_saver<Archive, T>::invoke(Archive&, const T&, unsigned int) [with Archive = boost::archive::binary_oarchive; T = Eigen::Matrix<double, 3, 1>]’
/usr/include/boost/serialization/split_free.hpp:74:5:   required from ‘void boost::serialization::split_free(Archive&, T&, unsigned int) [with Archive = boost::archive::binary_oarchive; T = Eigen::Matrix<double, 3, 1>]’
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp:193:7:   required from ‘void boost::serialization::serialize(Archive&, Eigen::Matrix<Scalar, A, B, C, D, E>&, unsigned int) [with Archive = boost::archive::binary_oarchive; Scalar = double; int A = 3; int B = 1; int C = 0; int D = 3; int E = 1]’
/usr/include/boost/serialization/serialization.hpp:128:9:   required from ‘void boost::serialization::serialize_adl(Archive&, T&, unsigned int) [with Archive = boost::archive::binary_oarchive; T = Eigen::Matrix<double, 3, 1>]’
/usr/include/boost/archive/detail/oserializer.hpp:148:5:   required from ‘void boost::archive::detail::oserializer<Archive, T>::save_object_data(boost::archive::detail::basic_oarchive&, const void_) const [with Archive = boost::archive::binary_oarchive; T = Eigen::Matrix<double, 3, 1>]’
/usr/include/boost/archive/detail/oserializer.hpp:101:1:   [ skipping 222 instantiation contexts ]
/usr/include/boost/archive/detail/oserializer.hpp:525:5:   required from ‘void boost::archive::save(Archive&, T&) [with Archive = boost::archive::binary_oarchive; T = const sm::pose_graph::PoseGraph]’
/usr/include/boost/archive/detail/common_oarchive.hpp:69:9:   required from ‘void boost::archive::detail::common_oarchive<Archive>::save_override(T&, int) [with T = const sm::pose_graph::PoseGraph; Archive = boost::archive::binary_oarchive]’
/usr/include/boost/archive/basic_binary_oarchive.hpp:75:7:   required from ‘void boost::archive::basic_binary_oarchive<Archive>::save_override(const T&, int) [with T = sm::pose_graph::PoseGraph; Archive = boost::archive::binary_oarchive]’
/usr/include/boost/archive/binary_oarchive_impl.hpp:51:9:   required from ‘void boost::archive::binary_oarchive_impl<Archive, Elem, Tr>::save_override(T&, int) [with T = const sm::pose_graph::PoseGraph; Archive = boost::archive::binary_oarchive; Elem = char; Tr = std::char_traits<char>]’
/usr/include/boost/archive/detail/interface_oarchive.hpp:63:9:   required from ‘Archive& boost::archive::detail::interface_oarchive<Archive>::operator<<(T&) [with T = const sm::pose_graph::PoseGraph; Archive = boost::archive::binary_oarchive]’
/home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:295:20:   required from here
/home/slynen/Documents/projects/Schweizer-Messer/sm_eigen/include/sm/eigen/serialization.hpp:54:11: error: ‘make_array’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
In file included from /usr/include/boost/archive/detail/oserializer.hpp:58:0,
                 from /usr/include/boost/archive/detail/interface_oarchive.hpp:23,
                 from /usr/include/boost/archive/detail/common_oarchive.hpp:22,
                 from /usr/include/boost/archive/basic_text_oarchive.hpp:32,
                 from /usr/include/boost/archive/text_oarchive.hpp:31,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_boost/include/sm/boost/serialization.hpp:5,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/Vertex.hpp:6,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/Edge.hpp:5,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/include/sm/pose_graph/PoseGraph.hpp:48,
                 from /home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/src/PoseGraph.cpp:43:
/usr/include/boost/serialization/array.hpp:127:12: note: ‘template<class T> const boost::serialization::array<T> boost::serialization::make_array(T_, std::size_t)’ declared here, later in the translation unit
make[3]: **\* [CMakeFiles/sm_pose_graph.dir/src/PoseGraph.cpp.o] Error 1
make[3]: Leaving directory `/home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/build'
make[2]: *** [CMakeFiles/sm_pose_graph.dir/all] Error 2
make[2]: Leaving directory`/home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/build'
make[1]: **\* [all] Error 2
make[1]: Leaving directory `/home/slynen/Documents/projects/Schweizer-Messer/sm_pose_graph/build'
make: **\* [all] Error 2
