### PR TITLE
removing c++11 flags from other packages to compile c98 for property tree

### DIFF
--- a/sm_property_tree/CMakeLists.txt
+++ b/sm_property_tree/CMakeLists.txt
@@ -36,6 +36,8 @@ rosbuild_add_library(${PROJECT_NAME}
   src/PropertyTreeImplementation.cpp
 )
 
+rosbuild_remove_compile_flags(${PROJECT_NAME} -std=c++0x -std-c++11)
+
 rosbuild_link_boost(${PROJECT_NAME} filesystem system)
 
 


### PR DESCRIPTION
This removes the exported -std=c++0x and -std=c++11 flags exported by other packages for the boost property tree library and thereby removes the compiler errors on clang and possibly others
