### PR TITLE
Cmake Script Adaptation

### DIFF
--- a/numpy_eigen/cmake/add_python_export_library.cmake
+++ b/numpy_eigen/cmake/add_python_export_library.cmake
@@ -17,7 +17,7 @@ MACRO(add_python_export_library TARGET_NAME PYTHON_MODULE_DIRECTORY )
 
   rosbuild_add_boost_directories()
   # Find Python
-  FIND_PACKAGE(PythonLibs REQUIRED)
+  FIND_PACKAGE(PythonLibs 2.7.4 REQUIRED)
   INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_DIRS})
 
   IF(APPLE)


### PR DESCRIPTION
Minor cmake adaptation that numpy_eigen compiles under Ubuntu 13.04 (force use of 2.7 libpython, instead of libpython 3.x which is default in Ubuntu 13.04)
