### PR TITLE
Cmake Script Adaptation V2.0

### DIFF
--- a/numpy_eigen/cmake/add_python_export_library.cmake
+++ b/numpy_eigen/cmake/add_python_export_library.cmake
@@ -17,7 +17,7 @@ MACRO(add_python_export_library TARGET_NAME PYTHON_MODULE_DIRECTORY )
 
   rosbuild_add_boost_directories()
   # Find Python
-  FIND_PACKAGE(PythonLibs 2.7.4 REQUIRED)
+  FIND_PACKAGE(PythonLibs 2.7 REQUIRED)
   INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_DIRS})
 
   IF(APPLE)


### PR DESCRIPTION
 Changing requirement of pylib to 2.7 that numpy_eigen compiles in Ubuntu 12.04 (as well as 13.04)
