### PR TITLE
rm ros platform from sm_logging

### DIFF
--- a/sm_logging/include/sm/logging/assert.h
+++ b/sm_logging/include/sm/logging/assert.h
@@ -88,8 +88,6 @@
  * Currently implemented for Windows (any platform), powerpc64, and x86
  */
 
-#include <ros/platform.h>
-
 #ifdef WIN32
 # if defined (__MINGW32__)
 #  define SM_ISSUE_BREAK() DebugBreak();


### PR DESCRIPTION
Remove platform header from sm_logging. Fixes #43 

@PeterMuehlfellner This header is not needed on Ubuntu. In any case you can create a pull-request for such changes which will then be verified on our build-server which runs Ubuntu 12.04.

@PeterMuehlfellner can you verify this works for you?
