### PR TITLE
Fixed numerical comparison unit-tests

### DIFF
--- a/sm_common/include/sm/numerical_comparisons.hpp
+++ b/sm_common/include/sm/numerical_comparisons.hpp
@@ -60,6 +60,7 @@ static inline ValueType_ maxTimesEpsilon(const ValueType_ a, const ValueType_ b,
 template<typename ValueType_>
 static bool approximatelyEqual(const ValueType_ a, const ValueType_ b, ValueType_ epsilon = std::numeric_limits<ValueType_>::epsilon())
 {
+  SM_ASSERT_GT(std::invalid_argument, epsilon, 0.0, "This method is only valid for an epsilon greater than 0.");
   return std::abs(a - b) <= internal::maxTimesEpsilon(a, b, epsilon);
 }
 
@@ -73,6 +74,7 @@ static bool approximatelyEqual(const ValueType_ a, const ValueType_ b, ValueType
 template<typename ValueType_>
 static bool definitelyGreaterThan(const ValueType_ a, const ValueType_ b, ValueType_ epsilon = std::numeric_limits<ValueType_>::epsilon())
 {
+  SM_ASSERT_GT(std::invalid_argument, epsilon, 0.0, "This method is only valid for an epsilon greater than 0.");
   return (a - b) > internal::maxTimesEpsilon(a, b, epsilon);
 }
 
@@ -86,6 +88,7 @@ static bool definitelyGreaterThan(const ValueType_ a, const ValueType_ b, ValueT
 template<typename ValueType_>
 static bool definitelyLessThan(const ValueType_ a, const ValueType_ b, ValueType_ epsilon = std::numeric_limits<ValueType_>::epsilon())
 {
+  SM_ASSERT_GT(std::invalid_argument, epsilon, 0.0, "This method is only valid for an epsilon greater than 0.");
   return (b - a) > internal::maxTimesEpsilon(a, b, epsilon);
 }
 


### PR DESCRIPTION
Fixed a couple of missing assertions that where checked in the unit-tests:
The failures of the unit-tests where:

```
(...)/sm_common/test/numerical_comparisons.cpp:12: Failure
Expected: sm::approximatelyEqual(1.0, 1.0, 0.0) throws an exception of type std::invalid_argument.
  Actual: it throws nothing.
```
