### PR TITLE
Fix/check same verbosity

### DIFF
--- a/sm_common/include/sm/serialization_macros.hpp
+++ b/sm_common/include/sm/serialization_macros.hpp
@@ -23,16 +23,16 @@
 #include <boost/shared_ptr.hpp>
 #include <sm/typetraits.hpp>
 
-namespace cv{
+namespace cv {
 class Mat;
-}
+}  // namespace cv
 
-namespace sm_serialization{
-namespace internal_types{
+namespace sm_serialization {
+namespace internal_types {
 typedef char yes;
 typedef int no;
-}
-}
+}  // namespace internal_types
+}  // namespace sm_serialization
 
 struct AnyT {
   template<class T> AnyT(const T &);
@@ -288,17 +288,46 @@ struct streamIf<false, A> {
     return "NA";
   }
 };
-}
-}
-}
 
-//these defines set the default behaviour if no verbosity argument is given
-#define SM_SERIALIZATION_CHECKSAME_VERBOSE(THIS, OTHER) \
-  SM_SERIALIZATION_CHECKSAME_IMPL(THIS, OTHER, true)
-#define SM_SERIALIZATION_CHECKMEMBERSSAME_VERBOSE(OTHER, MEMBER) \
-  SM_SERIALIZATION_CHECKMEMBERSSAME_IMPL(OTHER, MEMBER, true)
+struct VerboseChecker {
+  static bool SetVerbose(bool verbose) {
+    Instance().verbose_ = verbose;
+    return true;  // Intended.
+  }
+  static bool Verbose() {
+    return Instance().verbose_;
+  }
+ private:
+  static VerboseChecker& Instance() {
+    static VerboseChecker instance;
+    return instance;
+  }
+  VerboseChecker() : verbose_(false) { }
+  VerboseChecker(const VerboseChecker&);
+  VerboseChecker& operator==(const VerboseChecker&);
+  bool verbose_;
+};
+}  // namespace internal
+}  // namespace serialization
+}  // namespace sm
 
-#define SM_SERIALIZATION_CHECKSAME_IMPL(THIS, OTHER, VERBOSE) \
+#define IS_CHECKSAME_CURRENTLY_VERBOSE \
+  (sm::serialization::internal::VerboseChecker::Verbose())
+
+#define SET_CHECKSAME_VERBOSITY(verbose) \
+    sm::serialization::internal::VerboseChecker::SetVerbose(verbose)
+
+#define SET_CHECKSAME_VERBOSE \
+    SET_CHECKSAME_VERBOSITY(true)
+
+#define SET_CHECKSAME_SILENT \
+    SET_CHECKSAME_VERBOSITY(false)
+
+#define SM_SERIALIZATION_CHECKSAME_VERBOSE(THIS, OTHER, VERBOSE) \
+    SET_CHECKSAME_VERBOSITY(VERBOSE) && \
+    SM_SERIALIZATION_CHECKSAME_IMPL(THIS, OTHER)
+
+#define SM_SERIALIZATION_CHECKSAME_IMPL(THIS, OTHER) \
     (sm::serialization::internal::checkTypeIsNotOpencvMat<\
         typename sm::common::StripConstReference<decltype(OTHER)>::result_t, \
         false>::value &&  /*for opencvMats we have to use
@@ -309,8 +338,9 @@ struct streamIf<false, A> {
     typename sm::common::StripConstReference<decltype(OTHER)>::result_t>::value, \
     typename sm::common::StripConstReference<decltype(OTHER)>::result_t >::eval(THIS, OTHER)) ? \
         true : /*return true if good*/ \
-    (VERBOSE ? (std::cout <<  "*** Validation failed on " << #OTHER << ":\n"<< \
-        /*if not true, check whether VERBOSE and then try to output the
+    (IS_CHECKSAME_CURRENTLY_VERBOSE ? \
+        (std::cout <<  "*** Validation failed on " << #OTHER << ":\n"<< \
+        /* If not true, check whether VERBOSE and then try to output the
          * failed values using operator<<*/  \
     sm::serialization::internal::streamIf<\
     sm::serialization::internal::HasOStreamOperator<std::ostream, \
@@ -321,21 +351,25 @@ struct streamIf<false, A> {
     sm::serialization::internal::HasOStreamOperator<std::ostream,\
     typename sm::common::StripConstReference<decltype(OTHER)>::result_t>::value, \
     typename sm::common::StripConstReference<decltype(OTHER)>::result_t>::eval(OTHER) \
-    << "\nat " << __PRETTY_FUNCTION__ << /*we print the function where this happened*/ \
-    /*we print the line and file where this happened*/ \
+    << "\nat " << __PRETTY_FUNCTION__ << /* Print the function where this happened.*/ \
     " In: " << __FILE__ << ":" << __LINE__ << std::endl << std::endl) && false : false)
 
-#define SM_SERIALIZATION_CHECKMEMBERSSAME_IMPL(OTHER, MEMBER, VERBOSE) \
+#define SM_SERIALIZATION_CHECKMEMBERSSAME_VERBOSE(OTHER, MEMBER, VERBOSE) \
+    (SET_CHECKSAME_VERBOSITY(VERBOSE) && \
+        SM_SERIALIZATION_CHECKMEMBERSSAME_IMPL(OTHER, MEMBER)
+
+#define SM_SERIALIZATION_CHECKMEMBERSSAME_IMPL(OTHER, MEMBER) \
     ((sm::serialization::internal::checkTypeIsNotOpencvMat<\
         typename sm::common::StripConstReference<decltype(OTHER)>::result_t,\
-        false>::value) &&  /*for opencvMats we have to use sm::opencv::isBinaryEqual
-        otherwise this code has to depend on opencv*/\
+        false>::value) &&  /* For opencvMats we have to use sm::opencv::isBinaryEqual
+        otherwise this code has to depend on opencv.*/\
     (sm::serialization::internal::isSame<\
         sm::serialization::internal::HasIsBinaryEqual<\
         typename sm::common::StripConstReference<decltype(MEMBER)>::result_t>::value, \
     typename sm::common::StripConstReference<\
     decltype(MEMBER)>::result_t >::eval(this->MEMBER, OTHER.MEMBER))) ? \
-        true : (VERBOSE ? (std::cout <<  "*** Validation failed on " << #MEMBER << ":\n"<< \
+        true : (IS_CHECKSAME_CURRENTLY_VERBOSE ? \
+            (std::cout <<  "*** Validation failed on " << #MEMBER << ":\n"<< \
         sm::serialization::internal::streamIf<\
         sm::serialization::internal::HasOStreamOperator<std::ostream,\
         typename sm::common::StripConstReference<decltype(MEMBER)>::result_t>::value, \
@@ -347,24 +381,27 @@ struct streamIf<false, A> {
     << "\nat " << __PRETTY_FUNCTION__ << \
     " In: " << __FILE__ << ":" << __LINE__ << std::endl << std::endl) && false : false)
 
-//this is some internal default macro parameter deduction
+// This is some internal default macro parameter deduction.
 #define SM_SERIALIZATION_GET_3RD_ARG(arg1, arg2, arg3, ...) arg3
 #define SM_SERIALIZATION_GET_4TH_ARG(arg1, arg2, arg3, arg4, ...) arg4
 
 #define SM_SERIALIZATION_MACRO_CHOOSER_MEMBER_SAME(...) \
-    SM_SERIALIZATION_GET_4TH_ARG(__VA_ARGS__, SM_SERIALIZATION_CHECKMEMBERSSAME_IMPL,\
-                                 SM_SERIALIZATION_CHECKMEMBERSSAME_VERBOSE )
+    SM_SERIALIZATION_GET_4TH_ARG(__VA_ARGS__, SM_SERIALIZATION_CHECKMEMBERSSAME_VERBOSE,\
+                                 SM_SERIALIZATION_CHECKMEMBERSSAME_IMPL)
 #define SM_SERIALIZATION_MACRO_CHOOSER_SAME(...) \
-    SM_SERIALIZATION_GET_4TH_ARG(__VA_ARGS__, SM_SERIALIZATION_CHECKSAME_IMPL,\
-                                 SM_SERIALIZATION_CHECKSAME_VERBOSE )
+    SM_SERIALIZATION_GET_4TH_ARG(__VA_ARGS__, SM_SERIALIZATION_CHECKSAME_VERBOSE,\
+                                 SM_SERIALIZATION_CHECKSAME_IMPL)
 
-//\brief This macro checks this->MEMBER against OTHER.MEMBER  with the appropriate IsBinaryEqual or operator==.
-//Pointers and boost::shared_ptr are handled automatically
+//\brief This macro checks this->MEMBER against OTHER.MEMBER  with the
+// appropriate IsBinaryEqual or operator==.
+// Pointers and boost::shared_ptr are handled automatically.
 #define SM_CHECKMEMBERSSAME(...) \
   SM_SERIALIZATION_MACRO_CHOOSER_MEMBER_SAME(__VA_ARGS__)(__VA_ARGS__)
 
-//\brief This macro checks THIS against OTHER with the appropriate IsBinaryEqual or operator==.
-//Pointers and boost::shared_ptr are handled automatically
-#define SM_CHECKSAME(...) SM_SERIALIZATION_MACRO_CHOOSER_SAME(__VA_ARGS__)(__VA_ARGS__)
+//\brief This macro checks THIS against OTHER with the appropriate
+// IsBinaryEqual or operator==.
+// Pointers and boost::shared_ptr are handled automatically.
+#define SM_CHECKSAME(...) \
+  SM_SERIALIZATION_MACRO_CHOOSER_SAME(__VA_ARGS__)(__VA_ARGS__)
 
 #endif //SM_SERIALIZATION_MACROS_HPP

--- a/sm_common/test/serialization_macros.cpp
+++ b/sm_common/test/serialization_macros.cpp
@@ -194,11 +194,13 @@ TEST(SerializationMacros, TestClassesMacroWorks) {
   e1.setRandom();
   e2.setRandom();
 
+  SET_CHECKSAME_SILENT;
   ASSERT_FALSE(SM_CHECKSAME(e1, e2));
   ASSERT_FALSE(SM_CHECKSAME(e2, e1));
 
   e2 = e1;
 
+  SET_CHECKSAME_VERBOSE;
   ASSERT_TRUE(SM_CHECKSAME(e1, e2));
   ASSERT_TRUE(SM_CHECKSAME(e2, e1));
 
@@ -206,7 +208,6 @@ TEST(SerializationMacros, TestClassesMacroWorks) {
 
   ASSERT_TRUE(SM_CHECKSAME(e1, e3));
   ASSERT_TRUE(SM_CHECKSAME(e3, e1));
-
 }
 
 TEST(SerializationMacros, TestClassesCopyCtorAssignWorks) {


### PR DESCRIPTION
@PeterMuehlfellner This fixes #45 

I added an option to switch the verbosity on and off, with off being the default as you suggested. If you want the verbosity you can simply switch it globally on and off depending on your needs:

```
ComplexEntry e1, e2;
e1.setRandom();
e2.setRandom();
SET_CHECKSAME_SILENT;
ASSERT_FALSE(SM_CHECKSAME(e1, e2));

e2 = e1;

SET_CHECKSAME_VERBOSE;
ASSERT_TRUE(SM_CHECKSAME(e1, e2));
```

**Note:** Since verbosity is a global setting it is not threadsafe, e.g. if your tests run in parallel, you might get some artifacts.
