### PR TITLE
IO manipulation  include was missing, obfuscated by the fact that test i...

### DIFF
--- a/sm_common/include/sm/hash_id.hpp
+++ b/sm_common/include/sm/hash_id.hpp
@@ -3,6 +3,7 @@
 
 #include <chrono>
 #include <cstring>
+#include <iomanip>
 #include <sstream>
 
 namespace sm {


### PR DESCRIPTION
...ncludes iostream.
