### PR TITLE
Removed unnecessary SET_CHECKSAME_VERBOSE

### DIFF
--- a/sm_common/test/serialization_macros.cpp
+++ b/sm_common/test/serialization_macros.cpp
@@ -200,7 +200,6 @@ TEST(SerializationMacros, TestClassesMacroWorks) {
 
   e2 = e1;
 
-  SET_CHECKSAME_VERBOSE;
   ASSERT_TRUE(SM_CHECKSAME(e1, e2));
   ASSERT_TRUE(SM_CHECKSAME(e2, e1));
 


### PR DESCRIPTION
@simonlynen what I understand from #49 then is that someone left it there by accident there / forgot removing it after debugging?
