### PR TITLE
Setting CHECKSAME back to silent after completion of SerializationMacros...

### DIFF
--- a/sm_common/test/serialization_macros.cpp
+++ b/sm_common/test/serialization_macros.cpp
@@ -208,6 +208,8 @@ TEST(SerializationMacros, TestClassesMacroWorks) {
 
   ASSERT_TRUE(SM_CHECKSAME(e1, e3));
   ASSERT_TRUE(SM_CHECKSAME(e3, e1));
+
+  SET_CHECKSAME_SILENT;
 }
 
 TEST(SerializationMacros, TestClassesCopyCtorAssignWorks) {


### PR DESCRIPTION
....TestClassesMacroWorks in sm_common tests. In the spirit of verbosity being off per default as mentioned in #49 . This mostly to reduce output when debugging other tests from the sm_common suite.
