### PR TITLE
Fixing unit tests for hash id

### DIFF
--- a/sm_common/include/sm/hash_id.hpp
+++ b/sm_common/include/sm/hash_id.hpp
@@ -117,7 +117,7 @@ class HashId {
    * initialize in the same nanosecond.
    */
   inline static int64_t time64() {
-    std::chrono::system_clock::duration current =
+    std::chrono::high_resolution_clock::duration current =
         std::chrono::high_resolution_clock::now().time_since_epoch();
     using std::chrono::duration_cast;
     using std::chrono::nanoseconds;
@@ -135,6 +135,11 @@ class HashId {
   HashVal val_;
 };
 
+std::ostream& operator<<( std::ostream& out, const sm::HashId& hash ) {
+  out << hash.hexString();
+  return out;
+}
+
 } // namespace sm
 
 namespace std{
@@ -148,5 +153,6 @@ namespace std{
     }
   };
 } // namespace std
+
 
 #endif /* HASH_ID_HPP_ */

--- a/sm_common/test/hash_id.cpp
+++ b/sm_common/test/hash_id.cpp
@@ -43,6 +43,6 @@ TEST(SmCommonTestSuite, hashId_stdHash) {
   hashes.insert(needle);
   hashes.insert(HashId::random());
   std::unordered_set<HashId>::iterator found = hashes.find(needle);
-  EXPECT_NE(found, hashes.end());
+  EXPECT_TRUE(found != hashes.end());
   EXPECT_EQ(*found, needle);
 }


### PR DESCRIPTION
On osx these unit tests were failing. I'm not sure why they weren't failing on linux.
