### PR TITLE
Fix resolution of relative parents of relative parents in BoostPropertyTreeLoader

### DIFF
--- a/sm_property_tree/src/BoostPropertyTreeLoader.cpp
+++ b/sm_property_tree/src/BoostPropertyTreeLoader.cpp
@@ -61,7 +61,7 @@ class UpdateablePropertyTree {
 
     if (!parents.empty()) {
       ptl.info("Loading parents for " + configFile + ": " + parents);
-      readFiles(splitCommaSeparatedList(parents), ignore, configFile);
+      readFiles(splitCommaSeparatedList(parents), ignore, configFileFullPath);
     }
     updateOrSet(pt, configFileFullPath, updateOnly);
   }


### PR DESCRIPTION
Solution: Use absolute paths for relativeToFile in BoostPropertyTreeLoader::loadConfigFileWithParents

@FYI @huberya .